### PR TITLE
feat: allow use default key in membership by language config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,6 @@ omit =
     *admin.py
     */static/*
     */templates/*
+    */edxapp_wrapper/*
+    */settings/*
+    */tests/*

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,19 @@ Unreleased
 
 *
 
+0.12.0 - 2024-04-15
+**********************************************
+
+Updated
+=======
+
+* Moved Additional Features section to ``docs`` folder.
+
+Added
+=====
+
+* Added ``default`` key in membership by language configuration.
+
 0.11.0 - 2024-04-10
 **********************************************
 

--- a/docs/1-add-user-to-team-cohort-in-course-enrollment.rst
+++ b/docs/1-add-user-to-team-cohort-in-course-enrollment.rst
@@ -27,26 +27,41 @@ Add the configuration to the course in the **Advanced Settings** >
                     "type": "team",
                     "id": "<team-id>"
                 }
+            ],
+            "default": [
+                {
+                    "type": "team",
+                    "id": "<team-id>"
+                },
+                {
+                    "type": "cohort",
+                    "id": "<cohort-name>"
+                }
             ]
         }
     }
 
 The following keys are required:
 
-- The **language code** key must be in the ISO 639-1 format, the
-  `following codes`_ are supported. The string can contain multiple language
-  codes separated by commas, if you want to apply the same configuration to
-  multiple languages. Each language code should be a **list** of each of the
-  teams and cohorts you wish to assign to that language or languages.
+The **language code** key must be in the ISO 639-1 format, the `following codes`_
+are supported. The string can contain multiple language codes separated by
+commas, if you want to apply the same configuration to multiple languages.
 
-  Each team or cohort should be a dictionary with the following keys:
+Optionally, you can use the **default** key to set a configuration for when the
+user's language preference does not match any of the language codes in the
+configuration.
 
-  - **type**: The type of the group to which the user will be added. It can be
-    either "team" or "cohort".
-  - **id**: The identifier of the team or cohort to which the user will be
-    added. The value should be the team ID or cohort name. The team ID can be
-    found at the end of the URL when you view the team in the LMS (<lms-domain>/courses/<course-id>/teams/#teams/<topic-id>/**<team-id>**).
-    The cohort name is the name of the cohort you want to add the user to.
+Each language code should be a **list** of each of the teams and cohorts you
+wish to assign to that language or languages.
+
+Each team or cohort should be a dictionary with the following keys:
+
+- **type**: The type of the group to which the user will be added. It can be
+  either "team" or "cohort".
+- **id**: The identifier of the team or cohort to which the user will be
+  added. The value should be the team ID or cohort name. The team ID can be
+  found at the end of the URL when you view the team in the LMS (<lms-domain>/courses/<course-id>/teams/#teams/<topic-id>/**<team-id>**).
+  The cohort name is the name of the cohort you want to add the user to.
 
 The following is an example of a configuration:
 
@@ -69,6 +84,16 @@ The following is an example of a configuration:
                     "type": "team",
                     "id": "second-team-e3266314f27043fe95933fa036ecc570"
                 }
+            ],
+            "default": [
+                {
+                    "type": "team",
+                    "id": "default-team-e80b43a577c3474a8bbc7d80a7e57259"
+                },
+                {
+                    "type": "cohort",
+                    "id": "Default Cohort"
+                }
             ]
         }
     }
@@ -86,11 +111,15 @@ Considerations
 - By definition, the users cannot belong to more than one **cohort** nor to
   more that one **team** within the same team set (topic). Therefore, the
   configuration must be consistent with this restriction.
+- By definition, if a user unrolls from the course is not removed from the team
+  or cohort to which they were added.
+- If the configuration of a language is updated, the changes will only apply to
+  new enrollments. The users who were already enrolled will not be affected by
+  the changes. To apply the new configuration, the user or the instructor must
+  make the changes manually.
 - If a user changes their language preference, the user or the instructor
   must remove the user from the team or cohort that represents the previous
   language preference and add the user to the team or cohort that represents
   the new language preference. Alternatively, after the user is removed from
   the previous team or cohort, the user can enroll again in the course to be
   added to the new team or cohort.
-- If a user unrolls from the course is not removed from the team or cohort to
-  which they were added.

--- a/openedx_unidigital/__init__.py
+++ b/openedx_unidigital/__init__.py
@@ -2,4 +2,4 @@
 An Open edX plugin for the Unidigital project.
 """
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/openedx_unidigital/handlers.py
+++ b/openedx_unidigital/handlers.py
@@ -27,6 +27,9 @@ def add_member_to_course_group_by_language(enrollment, **kwargs) -> None:
     """
     Add user to course group (team/cohort) by language preference.
 
+    If the language preference of the user does not exist in the configuration,
+    the user will be added to the default group if it exists.
+
     - First, we get the configuration per language stored in other course settings.
     - Then, we get the user's language preference.
     - Finally, we add the user to the course group based on the user's language preference.
@@ -41,8 +44,11 @@ def add_member_to_course_group_by_language(enrollment, **kwargs) -> None:
     user = get_user_by_username_or_email(enrollment.user.pii.username)
     lang_pref = get_language_preference(user)
 
-    if lang_pref in membership_by_language:
-        add_user_to_course_group(user, membership_by_language[lang_pref], course_key)
+    course_groups = membership_by_language.get(
+        lang_pref, membership_by_language.get("default")
+    )
+    if course_groups:
+        add_user_to_course_group(user, course_groups, course_key)
 
 
 def add_user_to_course_group(user, course_groups: List[dict], course_key: str) -> None:

--- a/openedx_unidigital/tests/test_handlers.py
+++ b/openedx_unidigital/tests/test_handlers.py
@@ -115,6 +115,37 @@ class TestHandlers(TestCase):
         mock_get_language_preference.assert_called_once_with(self.user)
         mock_add_user_to_course_group.assert_not_called()
 
+    @patch(f"{HANDLERS_MODULE_PATH}.get_membership_by_language")
+    @patch(f"{HANDLERS_MODULE_PATH}.get_user_by_username_or_email")
+    @patch(f"{HANDLERS_MODULE_PATH}.get_language_preference")
+    @patch(f"{HANDLERS_MODULE_PATH}.add_user_to_course_group")
+    def test_add_member_to_course_group_by_language_with_default(
+        self,
+        mock_add_user_to_course_group: Mock,
+        mock_get_language_preference: Mock,
+        mock_get_user_by_username_or_email: Mock,
+        mock_get_membership_by_language: Mock,
+    ):
+        """Test `add_member_to_course_group_by_language` with default groups"""
+        self.lang_pref = "es"
+        default_groups = [
+            {"type": "team", "id": "team-id-default"},
+            {"type": "cohort", "id": "cohort-name-default"},
+        ]
+        self.membership_by_lang_conf["default"] = default_groups
+        mock_get_user_by_username_or_email.return_value = self.user
+        mock_get_language_preference.return_value = self.lang_pref
+        mock_get_membership_by_language.return_value = self.membership_by_lang_conf
+
+        add_member_to_course_group_by_language(self.enrollment)
+
+        mock_get_membership_by_language.assert_called_once_with(self.course_key)
+        mock_get_user_by_username_or_email.assert_called_once_with(self.username)
+        mock_get_language_preference.assert_called_once_with(self.user)
+        mock_add_user_to_course_group.assert_called_once_with(
+            self.user, default_groups, self.course_key
+        )
+
     @patch(f"{HANDLERS_MODULE_PATH}.add_user_to_team")
     @patch(f"{HANDLERS_MODULE_PATH}.add_user_to_cohort")
     def test_add_user_to_course_group_team_and_cohort(


### PR DESCRIPTION
### Description
This PR allows the instructor to use a default configuration optionally. If a default configuration is added, users with a language preference that does not match the configured ones will be added to the teams or cohorts in the default configuration.

### How to Test
1. Install this plugin in your environment and checkout to this branch.
2. Include this setting in your environment:

    ```yml
    name: openedx-unidigital-settings
    version: 0.1.0
    patches:
      openedx-common-settings: |
        FEATURES["ENABLE_TEAMS"] = True
        FEATURES["ENABLE_OTHER_COURSE_SETTINGS"] = True
    ```
3. Activate teams in your course from Studio > **Content** > **Page & Resources** > **Teams ✅** 
4. Create some teams in the course.
5. Activate cohorts in your course from LMS > **Instructor** > **Cohorts** > **Enable Cohorts ✅**
6. Create some cohorts in the course.
7. Configure other course settings from Studio > **Settings** > **Advanced Settings** > **Other Course Settings** with the following format:

    ```json
    {
        "MEMBERSHIP_BY_LANGUAGE_CONFIG": {
            "default": [
                {
                    "type": "team",
                    "id": "<team-id>"
                },
                {
                    "type": "cohort",
                    "id": "<cohort-name>"
                }
            ]
        }
    }
    ```
    For example:

    ```json
    {
        "MEMBERSHIP_BY_LANGUAGE_CONFIG": {
            "default": [
                {
                    "type": "team",
                    "id": "team-11-0cfde91f6f684dd6ad00e99c6b31dede"
                },
                {
                    "type": "cohort",
                    "id": "First Cohort"
                },
            ]
        }
    }
    ```
8. As a student, set your language preference from LMS > **Account** > **Site Preferences** > **Site Language**
9. As a student, enroll in the previously configured course. As your language preference is not in the configured ones, you will automatically added to the specified teams or cohorts in the default configuration.