### PR TITLE
build: drop support for old django/python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ['3.8']
-        toxenv: [quality, pii_check, django32, django40]
+        python-version: ['3.8', '3.11']
+        toxenv: [quality, pii_check, django42]
 
     steps:
     - uses: actions/checkout@v3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,9 +6,11 @@
 #
 asgiref==3.8.1
     # via django
-backports-zoneinfo==0.2.1
-    # via django
-django==4.2.11
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
+    # via
+    #   -c requirements/constraints.txt
+    #   django
+django==4.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -34,5 +34,5 @@ tomli==2.0.1
     #   tox
 tox==4.15.0
     # via -r requirements/ci.in
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,7 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+
+
+# Temporary to Support the python 3.11 Upgrade
+backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo available in the standard library

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,13 +8,14 @@ asgiref==3.8.1
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==3.1.0
+astroid==3.2.0
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-backports-zoneinfo==0.2.1
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   django
 black==24.4.2
@@ -67,7 +68,7 @@ distlib==0.3.8
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==4.2.11
+django==4.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -103,7 +104,7 @@ jinja2==3.1.4
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
-lxml[html-clean,html_clean]==5.2.1
+lxml[html-clean,html_clean]==5.2.2
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
@@ -164,7 +165,7 @@ pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.18.0
     # via diff-cover
-pylint==3.1.0
+pylint==3.2.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -244,7 +245,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -257,7 +258,7 @@ typing-extensions==4.11.0
     #   astroid
     #   black
     #   pylint
-virtualenv==20.26.1
+virtualenv==20.26.2
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,12 +8,13 @@ asgiref==3.8.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.1.0
+astroid==3.2.0
     # via
     #   pylint
     #   pylint-celery
-backports-zoneinfo==0.2.1
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django
 click==8.1.7
@@ -34,7 +35,7 @@ coverage[toml]==7.5.1
     #   pytest-cov
 dill==0.3.8
     # via pylint
-django==4.2.11
+django==4.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -82,7 +83,7 @@ pycodestyle==2.11.1
     # via -r requirements/quality.in
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==3.1.0
+pylint==3.2.0
     # via
     #   edx-lint
     #   pylint-celery
@@ -135,7 +136,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.12.4
+tomlkit==0.12.5
     # via pylint
 typing-extensions==4.11.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,8 +8,9 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-backports-zoneinfo==0.2.1
+backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django
 click==8.1.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{32,40}
+envlist = py{38,311}-django{42}
 
 [doc8]
 ; D001 = Line too long
@@ -36,8 +36,7 @@ norecursedirs = .* docs requirements site-packages
 
 [testenv]
 deps =
-    django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
+    django42: Django>=4.2,<4.3
     -r{toxinidir}/requirements/test.txt
 commands =
     python manage.py check


### PR DESCRIPTION
### Description

This PR drops support for old Django versions and adds support Python 3.11.